### PR TITLE
fix(export): save CSV/JSON via native dialog instead of blob download

### DIFF
--- a/app.go
+++ b/app.go
@@ -327,6 +327,25 @@ func (a *App) ExportSettings(includeSecrets bool) error {
 	return os.WriteFile(path, data, 0o600)
 }
 
+// SaveTextFile opens a native save dialog and writes text content to the chosen
+// path. Used to export messages (CSV/JSON): blob/anchor downloads triggered from
+// the frontend do not work inside the WebKit webview, so the export must be
+// written through the OS file dialog instead. Returns nil if the user cancels.
+func (a *App) SaveTextFile(defaultName, content string) error {
+	path, err := runtime.SaveFileDialog(a.ctx, runtime.SaveDialogOptions{
+		DefaultFilename: defaultName,
+		Filters: []runtime.FileFilter{
+			{DisplayName: "CSV Files", Pattern: "*.csv"},
+			{DisplayName: "JSON Files", Pattern: "*.json"},
+			{DisplayName: "All Files", Pattern: "*"},
+		},
+	})
+	if err != nil || path == "" {
+		return err
+	}
+	return os.WriteFile(path, []byte(content), 0o600)
+}
+
 // ImportSettings reads profiles from a user-chosen JSON file and merges them
 // (adds profiles not already present by ID), restoring passwords to keychain.
 // SelectCertificateFile opens a native file dialog for selecting certificate/key files.

--- a/frontend/src/shared/lib/exportMessages.ts
+++ b/frontend/src/shared/lib/exportMessages.ts
@@ -1,23 +1,22 @@
 import type { KafkaMessage } from '@entities/message'
+import { SaveTextFile } from '@shared/api'
 
-/** Triggers a browser download for the given content. */
-function download(filename: string, content: string, mimeType: string) {
-  const blob = new Blob([content], { type: mimeType })
-  const url = URL.createObjectURL(blob)
-  const a = document.createElement('a')
-  a.href = url
-  a.download = filename
-  a.click()
-  URL.revokeObjectURL(url)
+/**
+ * Writes content to a file chosen via the native OS save dialog.
+ * Blob/anchor downloads do not work inside the WebKit webview, so exporting
+ * must go through the bound Go method instead.
+ */
+function save(filename: string, content: string) {
+  return SaveTextFile(filename, content)
 }
 
 export function exportAsJson(messages: KafkaMessage[], topic: string) {
   const data = JSON.stringify(messages, null, 2)
-  download(`${topic}-${Date.now()}.json`, data, 'application/json')
+  return save(`${topic}-${Date.now()}.json`, data)
 }
 
 export function exportAsCsv(messages: KafkaMessage[], topic: string) {
-  const escape = (s: string) => `"${s.replace(/"/g, '""')}"`
+  const escape = (s: string) => `"${String(s ?? '').replace(/"/g, '""')}"`
   const header = 'partition,offset,timestamp,key,value,headers'
   const rows = messages.map((m) =>
     [
@@ -29,5 +28,5 @@ export function exportAsCsv(messages: KafkaMessage[], topic: string) {
       escape(JSON.stringify(m.headers)),
     ].join(','),
   )
-  download(`${topic}-${Date.now()}.csv`, [header, ...rows].join('\n'), 'text/csv')
+  return save(`${topic}-${Date.now()}.csv`, [header, ...rows].join('\n'))
 }

--- a/frontend/wailsjs/go/main/App.d.ts
+++ b/frontend/wailsjs/go/main/App.d.ts
@@ -80,6 +80,8 @@ export function ResetConsumerGroup(arg1:string,arg2:string,arg3:string,arg4:stri
 
 export function SavePlugin(arg1:plugin.Plugin):Promise<plugin.Plugin>;
 
+export function SaveTextFile(arg1:string,arg2:string):Promise<void>;
+
 export function SaveTopicGroup(arg1:string,arg2:string,arg3:profile.TopicGroup):Promise<void>;
 
 export function SelectCertificateFile():Promise<string>;

--- a/frontend/wailsjs/go/main/App.js
+++ b/frontend/wailsjs/go/main/App.js
@@ -150,6 +150,10 @@ export function SavePlugin(arg1) {
   return window['go']['main']['App']['SavePlugin'](arg1);
 }
 
+export function SaveTextFile(arg1, arg2) {
+  return window['go']['main']['App']['SaveTextFile'](arg1, arg2);
+}
+
 export function SaveTopicGroup(arg1, arg2, arg3) {
   return window['go']['main']['App']['SaveTopicGroup'](arg1, arg2, arg3);
 }


### PR DESCRIPTION
## Problem

The **Export as CSV / JSON** buttons appear broken. Export is implemented as a
browser blob download (`URL.createObjectURL` + `<a download>.click()`), which
the WebView does not handle consistently:

- **Linux (WebKitGTK):** the file is written silently to `~/Downloads` — no save
  dialog, no notification, so it looks like nothing happened.
- **macOS (WKWebView):** the anchor click does nothing at all.

## Fix

- Add a bound `SaveTextFile(defaultName, content)` method that writes the content
  to a path chosen via the native save dialog (`runtime.SaveFileDialog`),
  mirroring the existing `ExportSettings` pattern.
- `exportMessages.ts` now calls `SaveTextFile` instead of the blob download.
- Harden CSV cell escaping against `null`/`undefined` values (`String(s ?? '')`).

Result: a consistent native "Save as" dialog on all platforms.

## Testing

Built for `linux/amd64` (`wails build -tags webkit2_41`) and verified the save
dialog appears for both CSV and JSON export, writing correct files.